### PR TITLE
index.html: replace goraft with etcd/raft

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ Currently gogoprotobuf only has one extra tool, <a href="gogo.gitub.io/pbpath">p
 These projects use gogoprotobuf:
 
 <ul>
-  <li><a href="https://github.com/goraft/raft">goraft</a></li>
+  <li><a href="http://godoc.org/github.com/coreos/etcd/raft">etcd/raft</a></li>
   <li><a href="https://www.spacemonkey.com/">spacemonkey</a> - <a href="https://www.spacemonkey.com/blog/posts/go-space-monkey">go-space-monkey-blog-post</a></li>
   <li><a href="http://bazil.org">bazil</a></li>
   <li><a href="http://badoo.com">badoo</a></li>


### PR DESCRIPTION
goraft is currently unmaintained so prehaps it might be better not to advertise it. The etcd/raft uses gogo so have it take the place?